### PR TITLE
Tests for the KFold function

### DIFF
--- a/keras_med_io/utils/misc_utils.py
+++ b/keras_med_io/utils/misc_utils.py
@@ -90,7 +90,7 @@ def KFold(data_dir, splits = [0.6, 0.2, 0.2], return_dict = False):
     train, validate, test = np.split(df.sample(frac=1), [int(splits[0]*len(df)), int(splits[1]*len(df))])
     assert len(train) + len(validate) + len(test) == total, "There should be no file overlap."
     if return_dict:
-      fname_dict = {'train': train, 'val': validate, 'test': test}
+      fname_dict = {'train': list(train), 'val': list(validate), 'test': list(test)}
       return fname_dict
     else:
       return (list(train), list(validate), list(test))

--- a/keras_med_io/utils/misc_utils.py
+++ b/keras_med_io/utils/misc_utils.py
@@ -78,7 +78,10 @@ def KFold(data_dir, splits = [0.6, 0.2, 0.2], return_dict = False):
         splits: a list with 3 elements corresponding to the decimal train/val/test splits; [train, val, test]
         return_dict: whether or not you want to return a dictionary with the filenames organized
     Returns:
-        a dictionary of file ids for each set
+        if return_dict is True:
+            a dictionary of file ids for each set
+        elif return_dict is False:
+            tuple of lists of folds (train, validate, test)
     """
     assert np.sum(splits) == 1, "Please make sure that your splits add up to 1."
     splits = [splits[0], splits[1] + splits[0]]
@@ -90,7 +93,7 @@ def KFold(data_dir, splits = [0.6, 0.2, 0.2], return_dict = False):
       fname_dict = {'train': train, 'val': validate, 'test': test}
       return fname_dict
     else:
-      return train, validate, test
+      return (list(train), list(validate), list(test))
 
 def sanity_checks(patch_x, patch_y):
     """

--- a/tests/misc_utils_tests.py
+++ b/tests/misc_utils_tests.py
@@ -128,6 +128,33 @@ class Misc_Utils_Test(unittest.TestCase):
             self.assertTrue(val_new != val)
             self.assertTrue(test_new != test)
 
+    def test_KFold_withdict(self):
+        """
+        Tests that the KFold function: (return_dict = True)
+        1. produces unique folds
+        2. correctly divided folds (the right length wrt the provided percentages)
+        3. randomly outputs folds. (Will produce different folds each time)
+        """
+        n_files = len(os.listdir(self.train_npy_path))
+        # returns lists of files
+        id_dict = KFold(self.train_npy_path, splits = [0.6, 0.2, 0.2], return_dict = True)
+        train, val, test = id_dict['train'], id_dict['val'], id_dict['test']
+        # 1. testing that the folds have unique files
+        combined = train + val + test
+        self.assertEqual(n_files, len(combined))
+        self.assertEqual(n_files, np.unique(combined).size)
+         # 2. testing fold lengths
+        self.assertEqual(n_files * 0.6, len(train))
+        self.assertEqual(n_files * 0.2, len(val))
+        self.assertEqual(n_files * 0.2, len(test))
+        # 3. testing that the folds will be different each time (for 3 iterations)
+            # comparing newly generated to the original
+        for i in range(3):
+            id_dict_new = KFold(self.train_npy_path, splits = [0.6, 0.2, 0.2], return_dict = True)
+            self.assertTrue(id_dict_new['train'] != train)
+            self.assertTrue(id_dict_new['val'] != val)
+            self.assertTrue(id_dict_new['test'] != test)
+
     def test_add_channel(self):
         """
         Tests that add_channel adds a channel to the last dimension

--- a/tests/misc_utils_tests.py
+++ b/tests/misc_utils_tests.py
@@ -1,7 +1,8 @@
-from keras_med_io.utils.misc_utils import load_data, get_list_IDs, add_channel#,get_multi_class_labels
+from keras_med_io.utils.misc_utils import load_data, get_list_IDs, add_channel, get_multi_class_labels, KFold
 import unittest
 import os
 import nibabel as nib
+import numpy as np
 
 class Misc_Utils_Test(unittest.TestCase):
     """
@@ -84,7 +85,9 @@ class Misc_Utils_Test(unittest.TestCase):
 
     def test_get_list_IDs(self):
         """
-        Tests that get_list_IDs gets unique folds and that they are divided up correctly
+        Tests that get_list_IDs
+        1. produces unique files in the folds
+        2. correctly divides the folds (correct length)
         Note: We're using the path to the .npy files instead of the .nii.gz because the original directory
         had some unnecessary files that start with "._".
         """
@@ -98,6 +101,32 @@ class Misc_Utils_Test(unittest.TestCase):
         combined = id_dict['train'] + id_dict['val'] + id_dict['test']
         self.assertEqual(n_files, len(combined))
         self.assertEqual(n_files, np.unique(combined).size)
+
+    def test_KFold_nodict(self):
+        """
+        Tests that the KFold function: (return_dict = False)
+        1. produces unique folds
+        2. correctly divided folds (the right length wrt the provided percentages)
+        3. randomly outputs folds. (Will produce different folds each time)
+        """
+        n_files = len(os.listdir(self.train_npy_path))
+        # returns lists of files
+        train, val, test = KFold(self.train_npy_path, splits = [0.6, 0.2, 0.2], return_dict = False)
+        # 1. testing that the folds have unique files
+        combined = train + val + test
+        self.assertEqual(n_files, len(combined))
+        self.assertEqual(n_files, np.unique(combined).size)
+         # 2. testing fold lengths
+        self.assertEqual(n_files * 0.6, len(train))
+        self.assertEqual(n_files * 0.2, len(val))
+        self.assertEqual(n_files * 0.2, len(test))
+        # 3. testing that the folds will be different each time (for 3 iterations)
+            # comparing newly generated to the original
+        for i in range(3):
+            train_new, val_new, test_new = KFold(self.train_npy_path, splits = [0.6, 0.2, 0.2], return_dict = False)
+            self.assertTrue(train_new != train)
+            self.assertTrue(val_new != val)
+            self.assertTrue(test_new != test)
 
     def test_add_channel(self):
         """


### PR DESCRIPTION
Continuation of PR #6 
This PR consists of:
* two tests added to `misc_utils_tests.py`'s `Misc_Utils_Test` testcase for `KFold` for when `return_dict = False` and when `return_dict = True`.
* changes to the `KFold` function so that it returns lists rather than pandas Series (i.e. a dictionary of lists or tuple of lists)