### PR TITLE
Inference Module Fixes and Tests

### DIFF
--- a/keras_med_io/inference/infer_utils.py
+++ b/keras_med_io/inference/infer_utils.py
@@ -1,31 +1,31 @@
 import numpy as np
 
-def pad_nonint_extraction(image, orig_shape, coords):
+def pad_nonint_extraction(image, orig_shape, coords, pad_value = 0):
     """
-    Pads the cropped output from `io.io_utils`'s extract_nonint_region function
+    Pads the cropped output from `utils.shape_io`'s extract_nonint_region function
     Args:
-        image: either the mask or the thresholded (= 0.5) segmentation prediction (x, y, z)
-        orig_shape: Original shape of the 3D volume no channels
+        image: either the mask or the thresholded (= 0.5) segmentation prediction (x, y, z, n_channels)
+        orig_shape: Original shape of the 3D volume including the channels
         coords: outputted coordinates from `extract_nonint_region`
     Returns:
         padded: numpy array of shape `orig_shape`
     """
     # trying to reverse the cropping with padding
-    assert len(coords) == len(orig_shape), "Please make sure that the length of coords matches orig_shape."
-    padding = [[coords[i][0], orig_shape[i] - coords[i][1]] for i in range(len(orig_shape))]
-    padded = np.pad(image, padding, mode = 'constant', constant_values = 0)
+    assert (len(coords) + 1) == len(orig_shape), "Please make sure that orig_shape includes the channels dimension"
+    padding = [[coords[i][0], orig_shape[i]-coords[i][1]] for i in range(len(orig_shape[:-1]))] + [[0,0]]
+    padded = np.pad(image, padding, mode = 'constant', constant_values = pad_value)
     return padded
 
 def undo_reshape_padding(image, orig_shape):
     """
-    Undoes the padding done by the `reshape` function in `utils.io_func`
+    Undoes the padding done by the `reshape` function in `utils.shape_io`
     Args:
         image: numpy array that was reshaped to a larger size using reshape
         orig_shape: original shape before padding (do not include the channels)
     Returns:
         the reshaped image
     """
-    return image[:orig_img.shape[0], :orig_img.shape[1], :orig_img.shape[2]]
+    return image[:orig_shape[0], :orig_shape[1], :orig_shape[2]]
 
 # def load_data_predict():
 #     """

--- a/keras_med_io/utils/shape_io.py
+++ b/keras_med_io/utils/shape_io.py
@@ -53,9 +53,9 @@ def extract_nonint_region(image, mask = None, outside_value=0, coords = False):
     pos_idx = np.where(image != outside_value)
     # fetching all of the min/maxes for each axes
     pos_x, pos_y, pos_z = pos_idx[1], pos_idx[2], pos_idx[0]
-    minZidx, maxZidx = int(np.min(pos_z)), int(np.max(pos_z))
-    minXidx, maxXidx = int(np.min(pos_x)), int(np.max(pos_x))
-    minYidx, maxYidx = int(np.min(pos_y)), int(np.max(pos_y))
+    minZidx, maxZidx = int(np.min(pos_z)), int(np.max(pos_z)) + 1
+    minXidx, maxXidx = int(np.min(pos_x)), int(np.max(pos_x)) + 1
+    minYidx, maxYidx = int(np.min(pos_y)), int(np.max(pos_y)) + 1
     # resize images
     resizer = (slice(minZidx, maxZidx), slice(minXidx, maxXidx), slice(minYidx, maxYidx))
     coord_list = [[minZidx, maxZidx], [minXidx, maxXidx], [minYidx, maxYidx]]

--- a/tests/inference_tests.py
+++ b/tests/inference_tests.py
@@ -1,0 +1,56 @@
+from keras_med_io.inference.infer_utils import *
+from keras_med_io.utils.shape_io import extract_nonint_region, reshape
+import unittest
+import os
+import numpy as np
+
+class Infer_Utils_Test(unittest.TestCase):
+    """
+    Testing all the functions in inference/infer_utils:
+    * pad_nonint_extraction
+    * undo_reshape_padding
+    """
+    def setUp(self):
+        """
+        Initializing the parameters:
+            n_channels:
+            shapes: tuples with channels_first shapes
+            images & labels: numpy arrays
+            extractors: 2D and 3D versions for all the patch extractor classes.
+        """
+        self.n_channels = 4
+        self.image_shape_3D = (155, 240, 240, self.n_channels)
+        self.label_image_3D = np.ones(self.image_shape_3D)
+
+    def test_pad_nonint_extraction(self):
+        """
+        Tests that `pad_nonint_extraction`'s padding of the extracted image will produce the original shape.
+        """
+        # setting up a randomly padded image (pad with zeros)
+        self.padded_image_3D = np.pad(self.label_image_3D, ([20, 50], [20, 50], [20,50], [0,0]), mode = 'constant')
+        orig_shape = self.padded_image_3D.shape
+        # extracting image
+        extracted_img, coords = extract_nonint_region(self.padded_image_3D, outside_value = 0, coords = True)
+        # padding the extraction
+        padded_result = pad_nonint_extraction(extracted_img, orig_shape, coords)
+        # checking that the original and padded array are the same
+        self.assertEqual(padded_result.shape, orig_shape)
+        print("padded: ", np.unique(padded_result, return_counts = True), "\norig: ", np.unique(self.padded_image_3D, \
+                            return_counts = True))
+        self.assertTrue(np.array_equal(self.padded_image_3D, padded_result))
+
+    def test_undo_reshape_padding(self):
+        """
+        Tests that `undo_reshape_padding` will produce the original image from the padded image
+        """
+        # reshape(orig_img, append_value=-1024, new_shape=(512, 512, 512)
+        # setting up reshaped image
+        orig_shape = self.label_image_3D.shape
+        new_shape = (512, 512, 512, self.n_channels)
+        reshaped_img = reshape(self.label_image_3D, append_value = 0, new_shape = new_shape)
+        # undo padding
+        undone_img = undo_reshape_padding(reshaped_img, orig_shape)
+        # checking that the original and undo-padded array are the same
+        self.assertTrue(np.array_equal(undone_img, self.label_image_3D))
+
+unittest.main(argv=[''], verbosity=2, exit=False)


### PR DESCRIPTION
# Inference Change
* Fixed `extract_nonint_region`'s offset issue (where the extractions were a pixel off)
* can now specify the pad value for `pad_nonint_extraction`
* Made `undo_reshape_padding` actually work
# Inferences Tests
* Added tests for: `pad_nonint_extraction` and `undo_reshape_padding`